### PR TITLE
Feature: Category 페이지 게시글 수 표시

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,9 @@
   "license": "MIT",
   "scripts": {
     "build": "gatsby clean && gatsby build",
-    "develop": "gatsby develop",
-    "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
     "start": "gatsby develop",
     "serve": "gatsby serve",
     "clean": "gatsby clean",
-    "deploy": "gatsby build && gh-pages -d public",
     "deploy-prefix-paths": "gatsby build --prefix-paths && gh-pages -d public"
   },
   "dependencies": {

--- a/src/__generated__/gatsby-types.d.ts
+++ b/src/__generated__/gatsby-types.d.ts
@@ -3505,7 +3505,7 @@ type WebPOptions = {
 type CategoryPageQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-type CategoryPageQuery = { readonly allMdx: { readonly group: ReadonlyArray<{ readonly fieldValue: string | null, readonly totalCount: number }>, readonly nodes: ReadonlyArray<{ readonly id: string, readonly excerpt: string, readonly fields: { readonly slug: string | null } | null, readonly frontmatter: { readonly title: string, readonly category: string | null, readonly date: string | null, readonly tags: ReadonlyArray<string | null> | null } | null }> } };
+type CategoryPageQuery = { readonly allMdx: { readonly totalCount: number, readonly group: ReadonlyArray<{ readonly fieldValue: string | null, readonly totalCount: number }>, readonly nodes: ReadonlyArray<{ readonly id: string, readonly excerpt: string, readonly fields: { readonly slug: string | null } | null, readonly frontmatter: { readonly title: string, readonly category: string | null, readonly date: string | null, readonly tags: ReadonlyArray<string | null> | null } | null }> } };
 
 type GetSinglePostQueryVariables = Exact<{
   slug: InputMaybe<Scalars['String']>;

--- a/src/components/CategoryList/index.tsx
+++ b/src/components/CategoryList/index.tsx
@@ -6,33 +6,48 @@ import * as S from './style';
 
 interface CategoryProps {
   title: string;
+  count?: number;
   selectedCategory: string;
 }
 
 interface CategoryListProps {
+  totalCount: number;
   selectedCategory: string;
-  categories: Array<{ fieldValue: string }>;
+  categories: { fieldValue: string; totalCount: number }[];
 }
 
-const Category = ({ title, selectedCategory }: CategoryProps) => {
+const Category = ({ title, count, selectedCategory }: CategoryProps) => {
   return selectedCategory === title ? (
-    <S.Active>#{title}</S.Active>
+    <S.Active>
+      #{title}({count})
+    </S.Active>
   ) : (
-    <Link to={`/categories?q=${title}`}>
-      <S.Disabled>#{title}</S.Disabled>
-    </Link>
+    <S.Disabled>
+      <Link to={`/categories?q=${title}`}>
+        #{title}({count})
+      </Link>
+    </S.Disabled>
   );
 };
 
-const CategoryList = ({ selectedCategory, categories }: CategoryListProps) => {
+const CategoryList = ({
+  totalCount,
+  selectedCategory,
+  categories,
+}: CategoryListProps) => {
   return (
     <S.FlexWrapper>
       <S.CategoryListWrapper>
-        <Category title="all" selectedCategory={selectedCategory} />
+        <Category
+          title="all"
+          count={totalCount}
+          selectedCategory={selectedCategory}
+        />
         {categories.map((item, idx) => (
           <Category
             key={idx}
             title={item.fieldValue}
+            count={item.totalCount}
             selectedCategory={selectedCategory}
           />
         ))}

--- a/src/components/CategoryList/style.ts
+++ b/src/components/CategoryList/style.ts
@@ -12,10 +12,11 @@ export const Active = styled.li`
 `;
 
 export const Disabled = styled.li`
-  color: var(--textColor);
   border: 1px solid transparent;
-  border-radius: 6px;
   cursor: pointer;
+  a {
+    color: var(--textColor);
+  }
 `;
 
 export const CategoryListWrapper = styled.div`

--- a/src/gatsby-types.d.ts
+++ b/src/gatsby-types.d.ts
@@ -3514,7 +3514,7 @@ type WebPOptions = {
 type CategoryPageQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-type CategoryPageQuery = { readonly allMdx: { readonly group: ReadonlyArray<{ readonly fieldValue: string | null, readonly totalCount: number }>, readonly nodes: ReadonlyArray<{ readonly id: string, readonly excerpt: string, readonly fields: { readonly slug: string | null } | null, readonly frontmatter: { readonly title: string, readonly category: string | null, readonly date: string | null, readonly tags: ReadonlyArray<string | null> | null } | null }> } };
+type CategoryPageQuery = { readonly allMdx: { readonly totalCount: number, readonly group: ReadonlyArray<{ readonly fieldValue: string | null, readonly totalCount: number }>, readonly nodes: ReadonlyArray<{ readonly id: string, readonly excerpt: string, readonly fields: { readonly slug: string | null } | null, readonly frontmatter: { readonly title: string, readonly category: string | null, readonly date: string | null, readonly tags: ReadonlyArray<string | null> | null } | null }> } };
 
 type GatsbyImageSharpFixedFragment = { readonly base64: string | null, readonly width: number, readonly height: number, readonly src: string, readonly srcSet: string };
 

--- a/src/pages/categories.tsx
+++ b/src/pages/categories.tsx
@@ -11,7 +11,8 @@ import Divider from '@components/Divider';
 import PostList from '@components/PostList';
 
 const CategoryPage = ({ data }: PageProps<Queries.CategoryPageQuery>) => {
-  const { nodes, group } = data.allMdx;
+  const { nodes, group, totalCount } = data.allMdx;
+
   const [selectedQuery] = useQuery();
 
   const categories = orderBy(group, ['fieldValue'], ['asc']);
@@ -24,7 +25,11 @@ const CategoryPage = ({ data }: PageProps<Queries.CategoryPageQuery>) => {
     <Layout>
       <Seo title="Categories" />
       <PageTitle>Categories.</PageTitle>
-      <CategoryList selectedCategory={selectedQuery} categories={categories} />
+      <CategoryList
+        totalCount={totalCount}
+        selectedCategory={selectedQuery}
+        categories={categories}
+      />
       <Divider mt="0" />
       <PostList postList={filteredPosts} />
     </Layout>
@@ -34,6 +39,7 @@ const CategoryPage = ({ data }: PageProps<Queries.CategoryPageQuery>) => {
 export const pageQuery = graphql`
   query CategoryPage {
     allMdx(sort: { fields: frontmatter___date, order: DESC }) {
+      totalCount
       group(field: frontmatter___category) {
         fieldValue
         totalCount

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
+    "strictNullChecks": false,
     "skipLibCheck": true,
     "noEmit": true,
     "baseUrl": "./src",


### PR DESCRIPTION
### 📅 PR 생성 날짜

- 2023.06.29

### 📎 관련 이슈

resolve #21 

### 💬 작업 내용

- TypeScript nullCheck false로 변경
- package.json 불필요한 스크립트 변경
- Category 페이지에서 카테고리 별로 게시글 수 표시하도록 수정
