### PR TITLE
Feature/25 change post nav order

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -31,10 +31,11 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
   const { createNodeField } = actions;
   if (node.internal.type === `Mdx`) {
     const slug = createFilePath({ node, getNode, basePath: `content` });
+    const newSlug = `/${slug.split('/').reverse()[1]}/`;
     createNodeField({
       node,
       name: `slug`,
-      value: slug,
+      value: newSlug,
     });
   }
 };

--- a/src/components/Post/Footer/PostNavigator/index.tsx
+++ b/src/components/Post/Footer/PostNavigator/index.tsx
@@ -41,12 +41,12 @@ const PostCard = ({ right, node }: PostCardProps) => {
 };
 
 const PostNavigator = ({ pageContext }: PostNavigatorProps) => {
-  const { previous, next } = pageContext;
+  const { previous: newerPost, next: olderPost } = pageContext;
 
   return (
     <S.NavigatorWrapper>
-      {previous ? <PostCard node={previous} /> : <div />}
-      {next && <PostCard right node={next} />}
+      {olderPost ? <PostCard node={olderPost} /> : <div />}
+      {newerPost && <PostCard right node={newerPost} />}
     </S.NavigatorWrapper>
   );
 };


### PR DESCRIPTION
## 📑 포스트 navigation 순서(이전, 다음 포스트) 변경

### 📅 PR 생성 날짜

- 2023.09.20

### 📎 관련 이슈

resolve #25 

### 💬 작업 내용

- 현재 포스트 기준으로 이전 날짜 포스트를 이전 포스트, 이후 날짜 포스트를 다음 포스트가 되도록 변경
- 주소창의 경로에 카테고리가 포함되어 있던 것 삭제
